### PR TITLE
Do not discard key when evaluating first header

### DIFF
--- a/src/HttpMessage.php
+++ b/src/HttpMessage.php
@@ -154,12 +154,12 @@ abstract class HttpMessage {
             $headers = explode("\r\n", $headers);
         }
         
-        if (!count($headers)) {
+        if (empty($headers)) {
             return [];
         }
 
         // Strip the status line.
-        $firstLine = array_values($headers)[0];
+        $firstLine = reset($headers);
         if (strpos($firstLine, 'HTTP/') === 0) {
             array_shift($headers);
         }

--- a/src/HttpMessage.php
+++ b/src/HttpMessage.php
@@ -155,9 +155,9 @@ abstract class HttpMessage {
         }
 
         // Strip the status line.
-        $firstLine = array_shift($headers);
-        if (strpos($firstLine, 'HTTP/') !== 0) {
-            array_unshift($headers, $firstLine);
+        $firstLine = array_values($headers)[0];
+        if (strpos($firstLine, 'HTTP/') === 0) {
+            array_shift($headers);
         }
 
         $result = [];

--- a/src/HttpMessage.php
+++ b/src/HttpMessage.php
@@ -153,6 +153,10 @@ abstract class HttpMessage {
         if (is_string($headers)) {
             $headers = explode("\r\n", $headers);
         }
+        
+        if (!count($headers)) {
+            return [];
+        }
 
         // Strip the status line.
         $firstLine = array_values($headers)[0];

--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -213,8 +213,8 @@ class HttpRequest extends HttpMessage {
         $code = $info["http_code"];
         if ($response) {
             $header_size = $info["header_size"];
-            $rawHeaders = explode("\r\n", substr($response, 0, $header_size));
-            $status = array_shift($rawHeaders);
+            $rawHeaders = substr($response, 0, $header_size);
+            $status = null;
             $rawBody = substr($response, $header_size);
         } else {
             $status = $code;

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -159,7 +159,7 @@ class HttpResponse extends HttpMessage implements \ArrayAccess {
      *
      * A header string is the the form of the HTTP standard where each Key: Value pair is separated by `\r\n`.
      *
-     * @return HttpMessage Returns `$this` for fluent calls.
+     * @return HttpResponse Returns `$this` for fluent calls.
      */
     public function setHeaders($headers) {
         parent::setHeaders($headers);

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -91,13 +91,17 @@ class HttpResponse extends HttpMessage implements \ArrayAccess {
     /**
      * Initialize an instance of the {@link HttpResponse} object.
      *
-     * @param int $status The http response status.
-     * @param mixed $headers An array of response headers.
+     * @param int|null $status The http response status or null to get the status from the headers.
+     * @param array|string $headers An array of response headers or a header string.
      * @param string $rawBody The raw body of the response.
      */
     public function __construct($status = 200, $headers = '', $rawBody = '') {
-        $this->setStatus($status);
         $this->setHeaders($headers);
+        if (isset($status)) {
+            $this->setStatus($status);
+        } elseif (is_null($this->getStatusCode())) {
+            $this->setStatus(200);
+        }
         $this->rawBody = $rawBody;
     }
 
@@ -136,6 +140,32 @@ class HttpResponse extends HttpMessage implements \ArrayAccess {
         } else {
             $this->rawBody = '';
             $this->body = $body;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set all of the headers. This will overwrite any existing headers.
+     *
+     * @param array|string $headers An array or string of headers to set.
+     *
+     * The array of headers can be in the following form:
+     *
+     * - ["Header-Name" => "value", ...]
+     * - ["Header-Name" => ["lines, ...], ...]
+     * - ["Header-Name: value", ...]
+     * - Any combination of the above formats.
+     *
+     * A header string is the the form of the HTTP standard where each Key: Value pair is separated by `\r\n`.
+     *
+     * @return HttpMessage Returns `$this` for fluent calls.
+     */
+    public function setHeaders($headers) {
+        parent::setHeaders($headers);
+
+        if ($statusLine = $this->parseStatusLine($headers)) {
+            $this->setStatus($statusLine);
         }
 
         return $this;
@@ -267,6 +297,30 @@ class HttpResponse extends HttpMessage implements \ArrayAccess {
     public function setReasonPhrase($reasonPhrase) {
         $this->reasonPhrase = $reasonPhrase;
         return $this;
+    }
+
+    /**
+     * Parse the status line from a header string or array.
+     *
+     * @param string|array $headers Either a header string or a header array.
+     * @return string Returns the status line or an empty string if the first line is not an HTTP status.
+     */
+    private function parseStatusLine($headers) {
+        if (empty($headers)) {
+            return '';
+        }
+
+        if (is_string($headers)) {
+            $firstLine = trim(strstr($headers, "\r\n", true));
+        } else {
+            $firstLine = (string)reset($headers);
+        }
+
+        // Test the status line.
+        if (strpos($firstLine, 'HTTP/') === 0) {
+            return $firstLine;
+        }
+        return '';
     }
 
     /**

--- a/tests/HttpMessageTest.php
+++ b/tests/HttpMessageTest.php
@@ -299,4 +299,15 @@ class HttpMessageTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame(0, $response->getStatusCode());
         $this->assertStringStartsWith("Could not resolve host", $response->getReasonPhrase());
     }
+
+    /**
+     * Test the preservation of string keys in parseHeaders().
+     */
+    public function testHeaderKeyParsing() {
+        $msg = new HttpRequest();
+        $msg->setHeaders(['foo' => '1', 'bar' => '2']);
+
+        $this->assertSame('1', $msg->getHeader('foo'));
+        $this->assertSame('2', $msg->getHeader('bar'));
+    }
 }

--- a/tests/HttpMessageTest.php
+++ b/tests/HttpMessageTest.php
@@ -310,4 +310,47 @@ class HttpMessageTest extends \PHPUnit_Framework_TestCase {
         $this->assertSame('1', $msg->getHeader('foo'));
         $this->assertSame('2', $msg->getHeader('bar'));
     }
+
+    /**
+     * Test setting headers with a status line.
+     */
+    public function testParseHeadersWithStatus() {
+        $msg = new HttpResponse();
+        $msg->setHeaders("HTTP/1.1 201 Bamboozled\r\nFoo: bar\r\nX-Lookup-Mode: normal");
+
+        $this->assertSame('bar', $msg->getHeader('Foo'));
+        $this->assertSame('normal', $msg->getHeader('X-Lookup-Mode'));
+        $this->assertSame(201, $msg->getStatusCode());
+        $this->assertSame('Bamboozled', $msg->getReasonPhrase());
+    }
+
+    /**
+     * Test header overrides when constructing an {@link HttpResponse}.
+     */
+    public function testHeaderOverrides() {
+        $headerStr = "HTTP/1.1 201 Bamboozled\r\nFoo: bar\r\nX-Lookup-Mode: normal";
+
+        // An explicit status should override the one in the header.
+        $msg = new HttpResponse(404, $headerStr);
+        $this->assertSame(404, $msg->getStatusCode());
+        $this->assertSame('Not Found', $msg->getReasonPhrase());
+
+        // A null status should fetch from the header.
+        $msg2 = new HttpResponse(null, $headerStr);
+        $this->assertSame(201, $msg2->getStatusCode());
+        $this->assertSame('Bamboozled', $msg2->getReasonPhrase());
+
+    }
+
+    /**
+     * Test various scenarios where parseStatusLine is called.
+     */
+    public function testParseStatusLine() {
+        // Test parsing the status on an array without a status line.
+        $msg1 = new HttpResponse(333, ['Foo' => 'Bar']);
+        $this->assertSame(333, $msg1->getStatusCode());
+
+        $msg2 = new HttpResponse(null, ['Baz' => 'Bump']);
+        $this->assertSame(200, $msg2->getStatusCode());
+    }
 }


### PR DESCRIPTION
`parseHeader()` gets called for preparing outgoing headers (which have no status), not just for dealing with response headers. Current behavior removes the first header name when headers are in form `['User-Agent' => 'Some Agent']`. This preserve that name.

Currently, attempting to use this code:

``` php
        // Setup our request.
        parent::__construct('https://api.github.com');
        $this
            ->setDefaultHeader('Authorization', 'token '.$token)
            ->setDefaultHeader('User-Agent', $agent)
            ->setThrowExceptions(true);
```

results in the User-Agent header being destroyed before the request is sent.
