### PR TITLE
Properly handle multiple header blocks from redirected responses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ php:
 sudo: false
 
 matrix:
+    allow_failures:
+        - php: hhvm
     fast_finish: true
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,12 @@ matrix:
 
 install:
     - composer install
+    - composer require phpunit/phpunit ~5
     - travis/install-nginx.sh
 
 script:
     - curl -vsf 'http://garden-http.dev:8080/hello.json' &> /dev/stdout
-    - phpunit -c tests/phpunit.xml.dist --coverage-clover=coverage.clover
+    - ./vendor/bin/phpunit -c tests/phpunit.xml.dist --coverage-clover=coverage.clover
 
 addons:
     apt:

--- a/src/HttpMessage.php
+++ b/src/HttpMessage.php
@@ -153,21 +153,19 @@ abstract class HttpMessage {
         if (is_string($headers)) {
             $headers = explode("\r\n", $headers);
         }
-        
+
         if (empty($headers)) {
             return [];
-        }
-
-        // Strip the status line.
-        $firstLine = reset($headers);
-        if (strpos($firstLine, 'HTTP/') === 0) {
-            array_shift($headers);
         }
 
         $result = [];
         foreach ($headers as $key => $line) {
             if (is_numeric($key)) {
-                if (strstr($line, ': ')) {
+                if (strpos($line, 'HTTP/') === 0) {
+                    // Strip the status line and restart.
+                    $result = [];
+                    continue;
+                } elseif (strstr($line, ': ')) {
                     list($key, $line) = explode(': ', $line);
                 } else {
                     continue;

--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -62,7 +62,8 @@ class HttpRequest extends HttpMessage {
      *
      * - protocolVersion: The HTTP protocol version.
      * - verifyPeer: Whether or not to verify an SSL peer. Default true.
-     * - username/password: Used to send basic HTTP authentication with the request.
+     * - auth: A username/password used to send basic HTTP authentication with the request.
+     * - timeout: The number of seconds to wait before the request times out. A value of zero means no timeout.
      */
     public function __construct($method = self::METHOD_GET, $url = '', $body = '', array $headers = [], array $options = []) {
         $this->setMethod(strtoupper($method));

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -311,7 +311,11 @@ class HttpResponse extends HttpMessage implements \ArrayAccess {
         }
 
         if (is_string($headers)) {
-            $firstLine = trim(strstr($headers, "\r\n", true));
+            if (preg_match_all('`(?:^|\n)(HTTP/[^\r]+)\r\n`', $headers, $matches)) {
+                $firstLine = end($matches[1]);
+            } else {
+                $firstLine = trim(strstr($headers, "\r\n", true));
+            }
         } else {
             $firstLine = (string)reset($headers);
         }

--- a/tests/HttpMessageTest.php
+++ b/tests/HttpMessageTest.php
@@ -353,4 +353,38 @@ class HttpMessageTest extends \PHPUnit_Framework_TestCase {
         $msg2 = new HttpResponse(null, ['Baz' => 'Bump']);
         $this->assertSame(200, $msg2->getStatusCode());
     }
+
+    /**
+     * Responses that follow redirects will have multiple header blocks.
+     */
+    public function testRedirectFollowHeaders() {
+        $headers = <<<EOT
+HTTP/1.1 301 Moved Permanently\r
+Content-Type: text/html\r
+Date: Tue, 20 Jun 2017 21:10:19 GMT\r
+Location: https://example.com\r
+Connection: Keep-Alive\r
+Content-Length: 0\r
+\r
+HTTP/1.1 201 CREATED\r
+Server: nginx/1.10.1\r
+Date: Tue, 20 Jun 2017 21:10:20 GMT\r
+Content-Type: application/json; charset=utf-8\r
+Transfer-Encoding: chunked\r
+Connection: keep-alive\r
+P3P: CP="CAO PSA OUR"\r
+Cache-Control: no-cache\r
+Expires: Tue, 20 Jun 2017 21:10:19 GMT\r
+Pragma: no-cache\r
+X-Frame-Options: SAMEORIGIN\r
+X-Content-Type-Options: nosniff\r
+Strict-Transport-Security: max-age=63072000; includeSubdomains; preload\r
+Content-Encoding: gzip\r
+EOT;
+
+        $response = new HttpResponse(null, $headers, '{"foo": "bar"}');
+
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertFalse($response->hasHeader('Location'));
+    }
 }


### PR DESCRIPTION
If a request follows a redirect then the original header is included in
the response even though it should be discarded.