### PR TITLE
Update the default user agent to garden-http/2

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -48,7 +48,7 @@ class HttpClient {
      */
     public function __construct(string $baseUrl = '') {
         $this->baseUrl = $baseUrl;
-        $this->setDefaultHeader('User-Agent', 'garden-http/1.0.0 (HttpRequest)');
+        $this->setDefaultHeader('User-Agent', 'garden-http/2 (HttpRequest)');
         $this->middleware = function (HttpRequest $request): HttpResponse {
             return $request->send();
         };


### PR DESCRIPTION
I’m keeping the version number just at the major version to make maintenance easier.