### PR TITLE
Fix timeout not applying

### DIFF
--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -81,6 +81,7 @@ class HttpRequest extends HttpMessage {
         $this->setProtocolVersion($options['protocolVersion']);
         $this->setAuth($options['auth']);
         $this->setVerifyPeer($options['verifyPeer']);
+        $this->setTimeout($options['timeout']);
     }
 
     /**


### PR DESCRIPTION
The timeout was from the options was not being applied.

Due to the lack of documentation for the test setup I did not add any test covering this behaviour. It doesn't appear PHPUnit is even a dependency here.