### PR TITLE
Add a mock http client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /vendor/
 composer.lock
 coverage.clover
+**/.phpunit.result.cache
+

--- a/src/Mocks/MockHttpClient.php
+++ b/src/Mocks/MockHttpClient.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Http\Mocks;
+
+use Garden\Http\HttpClient;
+use Garden\Http\HttpRequest;
+use Garden\Http\HttpResponse;
+
+/**
+ * Mock HTTP client for testing. Does send actual HTTP requests.
+ */
+class MockHttpClient extends HttpClient {
+
+    use MockHttpResponseTrait;
+
+    /** @var HttpResponse */
+    private $currentResponse;
+
+    /**
+     * The default constructor adds request sending middleware. We don't want to do that.
+     * We're going to use our own middleware instead.
+     * @inheritdoc
+     */
+    public function __construct(string $baseUrl = '') {
+        parent::__construct($baseUrl);
+
+        // One big difference is the mock middleware starts with a response instead of a request.
+        $this->middleware = function (): HttpResponse {
+            return $this->getCurrentResponse();
+        };
+    }
+
+    /**
+     * Instead of making a web request, check our predefined responses and return one of those.
+     *
+     * @overrid
+     * @inheritdoc
+     */
+    public function request(string $method, string $uri, $body, array $headers = [], array $options = []) {
+        $key = $this->makeMockResponseKey($uri, $method);
+
+        // Lookup an existing mock response or send back a 404.
+        $this->currentResponse = $this->mockedResponses[$key] ?? new HttpResponse(404);
+        $this->addMiddleware(function (HttpRequest $request, callable $next): HttpResponse {
+            /** @var HttpResponse $response */
+            $response = $next($request);
+
+            // Make sure we attach the proper request to the response.
+            $response->setRequest($request);
+
+            return $response;
+        });
+
+        $request = $this->createRequest($method, $uri, $body, $headers, $options);
+        $response = call_user_func($this->middleware, $request);
+
+        if (!$response->isResponseClass('2xx')) {
+            $this->handleErrorResponse($response, $options);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @return HttpResponse
+     */
+    public function getCurrentResponse(): HttpResponse {
+        return $this->currentResponse;
+    }
+}

--- a/src/Mocks/MockHttpClient.php
+++ b/src/Mocks/MockHttpClient.php
@@ -18,58 +18,32 @@ class MockHttpClient extends HttpClient {
 
     use MockHttpResponseTrait;
 
+    /** @var MockHttpHandler */
+    private $mockHandler;
+
     /** @var HttpResponse */
     private $currentResponse;
 
     /**
-     * The default constructor adds request sending middleware. We don't want to do that.
-     * We're going to use our own middleware instead.
      * @inheritdoc
      */
     public function __construct(string $baseUrl = '') {
         parent::__construct($baseUrl);
-
-        // One big difference is the mock middleware starts with a response instead of a request.
-        $this->middleware = function (): HttpResponse {
-            return $this->getCurrentResponse();
-        };
+        $this->mockHandler = new MockHttpHandler();
+        $this->setHandler($this->mockHandler);
     }
 
     /**
-     * Instead of making a web request, check our predefined responses and return one of those.
+     * Add a single response to be queued up if a request is created.
      *
-     * @overrid
-     * @inheritdoc
+     * @param string $uri
+     * @param HttpResponse $response
+     * @param string $method
+     *
+     * @return $this
      */
-    public function request(string $method, string $uri, $body, array $headers = [], array $options = []) {
-        $key = $this->makeMockResponseKey($uri, $method);
-
-        // Lookup an existing mock response or send back a 404.
-        $this->currentResponse = $this->mockedResponses[$key] ?? new HttpResponse(404);
-        $this->addMiddleware(function (HttpRequest $request, callable $next): HttpResponse {
-            /** @var HttpResponse $response */
-            $response = $next($request);
-
-            // Make sure we attach the proper request to the response.
-            $response->setRequest($request);
-
-            return $response;
-        });
-
-        $request = $this->createRequest($method, $uri, $body, $headers, $options);
-        $response = call_user_func($this->middleware, $request);
-
-        if (!$response->isResponseClass('2xx')) {
-            $this->handleErrorResponse($response, $options);
-        }
-
-        return $response;
-    }
-
-    /**
-     * @return HttpResponse
-     */
-    public function getCurrentResponse(): HttpResponse {
-        return $this->currentResponse;
+    public function addMockResponse(string $uri, HttpResponse $response, string $method = HttpRequest::METHOD_GET) {
+        $this->mockHandler->addMockResponse($uri, $response, $method);
+        return $this;
     }
 }

--- a/src/Mocks/MockHttpHandler.php
+++ b/src/Mocks/MockHttpHandler.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Http\Mocks;
+
+use Garden\Http\HttpHandlerInterface;
+use Garden\Http\HttpRequest;
+use Garden\Http\HttpResponse;
+
+/**
+ * Handler for mock http requests. Never makes any actual network requests.
+ */
+class MockHttpHandler implements HttpHandlerInterface {
+
+    use MockHttpResponseTrait;
+
+    public function send(HttpRequest $request): HttpResponse {
+        $key = $this->makeMockResponseKey($request->getUrl(), $request->getMethod());
+        $response = $this->mockedResponses[$key] ?? new HttpResponse(404);
+        $response->setRequest($request);
+        return $response;
+    }
+}

--- a/src/Mocks/MockHttpResponseTrait.php
+++ b/src/Mocks/MockHttpResponseTrait.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Http\Mocks;
+
+use Garden\Http\HttpRequest;
+use Garden\Http\HttpResponse;
+
+/**
+ * Trait for mocking HTTP responses.
+ */
+trait MockHttpResponseTrait {
+    protected $mockedResponses = [];
+
+    /**
+     * Make the lookup key for a mock response.
+     *
+     * @param string $uri
+     * @param string $method
+     *
+     * @return string
+     */
+    private function makeMockResponseKey(string $uri, string $method = HttpRequest::METHOD_GET): string {
+        return $method . '-' . $uri;
+    }
+
+    /**
+     * Add a single response to be queued up if a request is created.
+     *
+     * @param string $uri
+     * @param HttpResponse $response
+     * @param string $method
+     *
+     * @return $this
+     */
+    public function addMockResponse(
+        string $uri,
+        HttpResponse $response,
+        string $method = HttpRequest::METHOD_GET
+    ) {
+        $key = $this->makeMockResponseKey($uri, $method);
+        $this->mockedResponses[$key] = $response;
+        return $this;
+    }
+}

--- a/tests/Mocks/MockHttpClientTest.php
+++ b/tests/Mocks/MockHttpClientTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @author Adam Charron <adam.c@vanillaforums.com>
+ * @copyright 2009-2019 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Http\Tests\Mocks;
+
+use Garden\Exception\NotFoundException;
+use Garden\Http\HttpRequest;
+use Garden\Http\HttpResponse;
+use Garden\Http\HttpResponseException;
+use Garden\Http\Mocks\MockHttpClient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for the mock http client.
+ */
+class MockHttpClientTest extends TestCase {
+
+    /**
+     * Test that mock responses are found or not found.
+     */
+    public function testMockResponses() {
+        $client = new MockHttpClient();
+        $mockedResponse = new HttpResponse(200, ['header' => 'value'], '');
+        $client->addMockResponse('/mock-endpoint?query=param', $mockedResponse, HttpRequest::METHOD_GET);
+        $result = $client->get('/mock-endpoint', ['query' => 'param']);
+        $this->assertEquals($mockedResponse, $result);
+
+        $client->addMockResponse('/mock-endpoint?query=param', $mockedResponse, HttpRequest::METHOD_DELETE);
+        $result = $client->delete('/mock-endpoint', ['query' => 'param']);
+        $this->assertEquals($mockedResponse, $result);
+    }
+
+    /**
+     * Test that non-matching requests go to not found.
+     */
+    public function testNotFound() {
+        $client = new MockHttpClient();
+        $mockedResponse = new HttpResponse(200, ['header' => 'value'], '');
+        $client->addMockResponse('/mock-endpoint?query=param', $mockedResponse, HttpRequest::METHOD_GET);
+
+        $result = $client->get('/not-mocked');
+        $this->assertEquals(404, $result->getStatusCode());
+
+        $result = $client->get('/mock-endpoint');
+        $this->assertEquals(404, $result->getStatusCode(), 'Query params must match');
+
+        $result = $client->delete('/mock-endpoint?query=param');
+        $this->assertEquals(404, $result->getStatusCode(), 'Http method must match');
+    }
+
+
+    /**
+     * Test that non-matching requests go to not found.
+     */
+    public function testExceptionsThrownWithMock() {
+        $client = new MockHttpClient();
+        $client->setThrowExceptions(true);
+
+        $this->expectException(HttpResponseException::class);
+        $client->get('/not-mocked');
+    }
+
+    /**
+     * Test that non-matching requests go to not found.
+     */
+    public function testMiddlewareApplies() {
+        $client = new MockHttpClient();
+
+        $client->addMiddleware(function (HttpRequest $request, callable $next): HttpResponse {
+            $request->addHeader('request-header', 'foo');
+            $response = $next($request);
+            $response->addHeader('response-header', 'bar');
+            return $response;
+        });
+
+        $response = $client->get('/not-mocked');
+        $this->assertEquals('bar', $response->getHeader('response-header'));
+        $this->assertEquals('foo', $response->getRequest()->getHeader('request-header'));
+    }
+}


### PR DESCRIPTION
This PR adds a `MockHttpClient` and trait so users using this library can have a mock for their tests. A primary use is to use this code in our hosted-queue job tests.

As the mock is to be published, I've added some tests that show
- Mock responses being registered and returned.
- Not found handling for unmocked responses.
- Middleware working on the mock responses.

This code is mostly similar to the code from vanilla's `VanillaTests\Fixtures` namespace. That code will be removed once this is merged and updated.