### PR TITLE
Add support for reusing cURL handle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ dist: xenial
 
 sudo: false
 
+env:
+    global:
+        # https://travis-ci.community/t/xdebug-3-is-installed-by-default-breaking-builds/10748
+        - XDEBUG_MODE=coverage
+
 matrix:
     allow_failures:
         - php: nightly

--- a/src/CurlHandler.php
+++ b/src/CurlHandler.php
@@ -188,4 +188,13 @@ class CurlHandler implements HttpHandlerInterface {
 
         return $response;
     }
+
+    /**
+     * Destroy any existing cURL handlers when the object is destroy
+     */
+    public function __destruct() {
+        if ($this->curl) {
+            curl_close($this->curl);
+        }
+    }
 }

--- a/src/CurlHandler.php
+++ b/src/CurlHandler.php
@@ -12,7 +12,7 @@ namespace Garden\Http;
  */
 class CurlHandler implements HttpHandlerInterface {
     /**
-     * @var curl handle to be (re)used
+     * @var resource|\CurlHandle cURL handle to be (re)used
      */
     protected $curl = null;
 
@@ -138,8 +138,11 @@ class CurlHandler implements HttpHandlerInterface {
     /**
      * Closes the cURL handle.
      */
-    protected function closeCurl() {
-        curl_close($this->curl);
+    public function closeConnection() {
+        if ($this->curl) {
+            curl_close($this->curl);
+        }
+
         $this->curl = null;
     }
 
@@ -183,14 +186,14 @@ class CurlHandler implements HttpHandlerInterface {
             || strcasecmp($request->getHeader('connection'), 'close') === 0
             || strcasecmp($response->getHeader('connection'), 'close') === 0
         ) {
-            $this->closeCurl();
+            $this->closeConnection();
         }
 
         return $response;
     }
 
     /**
-     * Destroy any existing cURL handlers when the object is destroy
+     * Destroy any existing cURL handlers when the object is destroyed
      */
     public function __destruct() {
         if ($this->curl) {

--- a/src/CurlHandler.php
+++ b/src/CurlHandler.php
@@ -12,6 +12,29 @@ namespace Garden\Http;
  */
 class CurlHandler implements HttpHandlerInterface {
     /**
+     * @var curl handle to be (re)used
+     */
+    protected $curl = null;
+
+    /**
+     * Gets a cURL resource for this request
+     *
+     * @param HttpRequest $request
+     * @return resource cURL handle
+     */
+    protected function getCurlHandle(HttpRequest $request) {
+        if ($this->curl === null) {
+            $this->curl = curl_init();
+        } elseif (!$request->hasHeader('connection') || strcasecmp($request->getHeader('connection'), 'close') === 0) {
+            // we have a reusable curl instance, but this request doesn't want to be shared. Close it and make a new one
+            curl_close($this->curl);
+            $this->curl = curl_init();
+        }
+
+        return $this->curl;
+    }
+
+    /**
      * Create the cURL resource that represents this request.
      *
      * @param HttpRequest $request The request to create the cURL resource for.
@@ -19,7 +42,7 @@ class CurlHandler implements HttpHandlerInterface {
      * @see curl_init(), curl_setopt(), curl_exec()
      */
     protected function createCurl(HttpRequest $request) {
-        $ch = curl_init();
+        $ch = $this->getCurlHandle($request);
 
         // Add the body first so we can calculate a content length.
         $body = '';
@@ -113,6 +136,14 @@ class CurlHandler implements HttpHandlerInterface {
     }
 
     /**
+     * Closes the cURL handle.
+     */
+    protected function closeCurl() {
+        curl_close($this->curl);
+        $this->curl = null;
+    }
+
+    /**
      * Decode a curl response and turn it into
      *
      * @param $ch
@@ -146,8 +177,14 @@ class CurlHandler implements HttpHandlerInterface {
         $ch = $this->createCurl($request);
         $curlResponse = $this->execCurl($ch);
         $response = $this->decodeCurlResponse($ch, $curlResponse);
-        curl_close($ch);
         $response->setRequest($request);
+
+        if (!$request->hasHeader('connection')
+            || strcasecmp($request->getHeader('connection'), 'close') === 0
+            || strcasecmp($response->getHeader('connection'), 'close') === 0
+        ) {
+            $this->closeCurl();
+        }
 
         return $response;
     }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -228,7 +228,7 @@ class HttpClientTest extends TestCase {
 
         $this->assertNotEquals(
             $this->getClientPort($api, ['Connection' => 'keep-alive']),
-            $this->getClientPort($api),
+            $this->getClientPort($api)
         );
     }
 
@@ -241,7 +241,7 @@ class HttpClientTest extends TestCase {
 
         $this->assertNotEquals(
             $this->getClientPort($api, ['Connection' => 'keep-alive']),
-            $this->getClientPort($api, ['Connection' => 'close']),
+            $this->getClientPort($api, ['Connection' => 'close'])
         );
     }
 

--- a/tests/index.php
+++ b/tests/index.php
@@ -33,7 +33,8 @@ namespace Garden {
             'headers' => $request->getHeaders(),
             'query' => $request->getQuery(),
             'body' => $request->getInput(),
-            'foo' => 'bar'
+            'foo' => 'bar',
+            'phpServer' => $_SERVER
         ];
 
         return $result;

--- a/travis/default-site.tpl.conf
+++ b/travis/default-site.tpl.conf
@@ -19,6 +19,7 @@ server {
         fastcgi_param             PHP_SELF $fastcgi_script_name;
         fastcgi_param             SCRIPT_FILENAME $document_root/index.php;
         fastcgi_param             X_REWRITE $request_rewrite;
+        fastcgi_param             X_CLIENT_PORT $remote_port;
 
         fastcgi_pass              php;
     }


### PR DESCRIPTION
Uses the HTTP `Connection` header to determine whether the cURL handle needs to be reused.

By the reusing the cURL handle, we can properly handle HTTP Keep-Alive which allows to send multiple requests over the same connection. This is especially useful when making multiple API requests over HTTPS, making the second and further requests execute with zero round-trip delay. Useful when making multiple requests to a cache or API that needs to respond quickly.

I originally wanted to clean up the code a little bit and make everything use `$this->curl` instead so there is a single source of truth for the cURL handler, but that would have been a breaking change for things extending `CurlHandler->execCurl`, such as [SafeCurlHttpHandler](https://github.com/vanilla/vanilla/blob/master/library/Vanilla/Web/SafeCurlHttpHandler.php).