### PR TITLE
Fix `MockRequest`'s `match()` function

### DIFF
--- a/src/Mocks/MockRequest.php
+++ b/src/Mocks/MockRequest.php
@@ -57,7 +57,7 @@ class MockRequest {
             return false;
         }
 
-        if ($incomingUrlParts['path'] !== $ownUrlParts['path']) {
+        if (isset($incomingUrlParts['path']) && ($incomingUrlParts['path'] !== $ownUrlParts['path'])) {
             // Wrong path. No match.
             $this->setScore(0);
             return false;


### PR DESCRIPTION
This small followup PR is related to all of these:

- https://github.com/vanilla/garden-http/pull/28
- https://github.com/vanilla/vanilla-cloud/pull/4658
- https://github.com/vanilla/vanilla-cloud/pull/4720
- https://github.com/vanilla/vanilla-cloud/pull/4727

Basically our match() function is parsing(`parse_url()`) the request's url but we are subsequently wrongly assuming that the returning array value contains a `path` value. This fix is adding a simple check before doing the verification.