### PR TITLE
Improve exceptions by adding request/response context and json_serialize support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
 	"require": {
 		"php": ">=7.4",
 		"ext-curl": "*",
-		"ext-json": "*"
+		"ext-json": "*",
+		"vanilla/garden-utils": "^1.1"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.0",

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -150,13 +150,7 @@ class HttpClient {
      */
     public function handleErrorResponse(HttpResponse $response, $options = []) {
         if ($options['throw'] ?? $this->throwExceptions) {
-            $body = $response->getBody();
-            if (is_array($body)) {
-                $message = $body['message'] ?? $response->getReasonPhrase();
-            } else {
-                $message = $response->getReasonPhrase();
-            }
-            throw new HttpResponseException($response, $message);
+            throw $response->asException();
         }
     }
 

--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -11,7 +11,7 @@ namespace Garden\Http;
 /**
  * Representation of an outgoing, client-side request.
  */
-class HttpRequest extends HttpMessage {
+class HttpRequest extends HttpMessage implements \JsonSerializable {
     /// Constants ///
 
     const METHOD_DELETE = 'DELETE';
@@ -215,6 +215,18 @@ class HttpRequest extends HttpMessage {
             'auth' => $this->getAuth(),
             'timeout' => $this->getTimeout(),
             'verifyPeer' => $this->getVerifyPeer()
+        ];
+    }
+
+    /**
+     * Basic JSON implementation.
+     *
+     * @return array
+     */
+    public function jsonSerialize(): array {
+        return [
+            "url" => $this->getUrl(),
+            "method" => $this->getMethod(),
         ];
     }
 }

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -455,9 +455,9 @@ class HttpResponse extends HttpMessage implements \ArrayAccess, \JsonSerializabl
 
         $body = $this->getBody();
         if (is_array($body) && isset($body['message']) && is_string($body['message'])) {
-            $responseMessage = "and a custom message of {$body['message']}";
+            $responseMessage = "and a custom message of \"{$body['message']}\"";
         } else {
-            $responseMessage = "and a standard message of {$this->getReasonPhrase()}";
+            $responseMessage = "and a standard message of \"{$this->getReasonPhrase()}\"";
         }
 
         $message = implode(" ", [$requestID, $responseAction, $responseMessage]);

--- a/src/HttpResponseException.php
+++ b/src/HttpResponseException.php
@@ -9,11 +9,12 @@
 namespace Garden\Http;
 
 use Garden\Utils\ContextException;
+use Monolog\Utils;
 
 /**
  * An exception that occurs when there is a non 2xx response.
  */
-class HttpResponseException extends ContextException {
+class HttpResponseException extends ContextException implements \JsonSerializable {
     /**
      * @var HttpResponse
      */
@@ -29,8 +30,8 @@ class HttpResponseException extends ContextException {
         $responseJson = $response->jsonSerialize();
         unset($responseJson['request']);
         $context = [
-            "response" => $response,
-            "request" => $response->getRequest(),
+            "response" => $responseJson,
+            "request" => $response->getRequest()->jsonSerialize(),
         ];
         parent::__construct($message, $response->getStatusCode(), $context);
         $this->response = $response;
@@ -54,5 +55,18 @@ class HttpResponseException extends ContextException {
      */
     public function getResponse(): HttpResponse {
         return $this->response;
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize(): array {
+        $result = [
+            'message' => $this->getMessage(),
+            'status' => (int) $this->getHttpStatusCode(),
+            'class' => get_class($this),
+            'code' => (int) $this->getCode(),
+        ] + $this->getContext();
+        return $result;
     }
 }

--- a/src/HttpResponseException.php
+++ b/src/HttpResponseException.php
@@ -8,10 +8,12 @@
 
 namespace Garden\Http;
 
+use Garden\Utils\ContextException;
+
 /**
  * An exception that occurs when there is a non 2xx response.
  */
-class HttpResponseException extends \Exception {
+class HttpResponseException extends ContextException {
     /**
      * @var HttpResponse
      */
@@ -24,7 +26,13 @@ class HttpResponseException extends \Exception {
      * @param string $message The error message.
      */
     public function __construct(HttpResponse $response, $message = "") {
-        parent::__construct($message, $response->getStatusCode(), null);
+        $responseJson = $response->jsonSerialize();
+        unset($responseJson['request']);
+        $context = [
+            "response" => $response,
+            "request" => $response->getRequest(),
+        ];
+        parent::__construct($message, $response->getStatusCode(), $context);
         $this->response = $response;
     }
 

--- a/tests/HttpMessageTest.php
+++ b/tests/HttpMessageTest.php
@@ -298,7 +298,7 @@ HEADERS;
      * Test requesting to an host that doesn't resolve.
      */
     public function testUnresolvedUrl() {
-        $request = new HttpRequest("GET", "http://foo.foo");
+        $request = new HttpRequest("GET", "http://foo.example");
         $request->setTimeout(1);
         $response = $request->send();
 

--- a/tests/HttpResponseExceptionTest.php
+++ b/tests/HttpResponseExceptionTest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @copyright 2009-2023 Vanilla Forums Inc.
+ * @license MIT
+ */
+
+namespace Garden\Http\Tests;
+
+use Garden\Http\HttpRequest;
+use Garden\Http\HttpResponse;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for exceptions.
+ */
+class HttpResponseExceptionTest extends TestCase {
+
+    /**
+     * Test json serialize implementation of exceptions.
+     */
+    public function testJsonSerialize(): void {
+        $response = new HttpResponse(501, ["content-type" => "application/json"], '{"message":"Some error occured."}');
+        $response->setRequest(new HttpRequest("POST", "/some/path"));
+        $this->assertEquals([
+            "message" => 'Request POST /some/path failed with a response code of 501 and a custom message of "Some error occured."',
+            "status" => 501,
+            "code" => 501,
+            "request" => [
+                'url' => '/some/path',
+                'method' => 'POST',
+            ],
+            "response" => [
+                'statusCode' => 501,
+                'content-type' => 'application/json',
+                'body' => '{"message":"Some error occured."}',
+            ],
+            'class' => 'Garden\Http\HttpResponseException',
+        ], $response->asException()->jsonSerialize());
+    }
+}


### PR DESCRIPTION
This PR improves our exceptions in garden-http by doing the following:

- Exceptions now extends `Garden\Utils\ContextException`.
- Exceptions now have `request` and `response` data in the their context and implement `JsonSerialize`
- Exceptions now have have their request path, method and response code in their message.
- `Request` and `Response` now implement `JsonSerialize`