### PR TITLE
Add PSR-7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,12 @@
 		"php": ">=7.4",
 		"ext-curl": "*",
 		"ext-json": "*",
-		"vanilla/garden-utils": "^1.1"
+		"vanilla/garden-utils": "^1.1",
+		"psr/http-message": "^1.1",
+		"slim/psr7": "^1.6"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "^9.0",
-		"slim/psr7": "^1.6",
 		"slim/slim": "^4.11",
 		"slim/http": "^1.3"
 	},

--- a/src/CurlHandler.php
+++ b/src/CurlHandler.php
@@ -181,6 +181,7 @@ class CurlHandler implements HttpHandlerInterface {
         $curlResponse = $this->execCurl($ch);
         $response = $this->decodeCurlResponse($ch, $curlResponse);
         $response->setRequest($request);
+        $request->setResponse($response);
 
         if (!$request->hasHeader('connection')
             || strcasecmp($request->getHeader('connection'), 'close') === 0

--- a/src/HttpMessage.php
+++ b/src/HttpMessage.php
@@ -8,12 +8,15 @@
 namespace Garden\Http;
 
 
+use Psr\Http\Message\MessageInterface;
+use Psr\Http\Message\StreamInterface;
+
 /**
  * HTTP messages consist of requests from a client to a server and responses from a server to a client.
  *
  * This is the base class for both the {@link HttpRequest} class and the {@link HttpResponse} class.
  */
-abstract class HttpMessage {
+abstract class HttpMessage implements MessageInterface {
     /// Properties ///
 
     /**
@@ -166,7 +169,7 @@ abstract class HttpMessage {
                     $result = [];
                     continue;
                 } elseif (strstr($line, ': ')) {
-                    list($key, $line) = explode(': ', $line);
+                    [$key, $line] = explode(': ', $line);
                 } else {
                     continue;
                 }
@@ -254,5 +257,59 @@ abstract class HttpMessage {
     public function setBody($body) {
         $this->body = $body;
         return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withProtocolVersion(string $version): self {
+        $cloned = clone $this;
+        $cloned->protocolVersion = $version;
+        return $cloned;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getHeaderLine(string $name) {
+        $headerLines = $this->getHeaderLines($name);
+        return implode(",", $headerLines);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withHeader(string $name, $value) {
+        $cloned = clone $this;
+        $cloned->setHeader($name, $value);
+        return $cloned;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withAddedHeader(string $name, $value) {
+        $cloned = clone $this;
+        $cloned->addHeader($name, $value);
+        return $cloned;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withoutHeader(string $name) {
+        $cloned = clone $this;
+        unset($cloned->headers[$name]);
+        unset($cloned->headerNames[$name]);
+        return $cloned;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withBody(StreamInterface $body) {
+        $cloned = clone $this;
+        $cloned->setBody($body->getContents());
+        return $cloned;
     }
 }

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -8,10 +8,12 @@
 namespace Garden\Http;
 
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Representation of an outgoing, server-side response.
  */
-class HttpResponse extends HttpMessage implements \ArrayAccess, \JsonSerializable {
+class HttpResponse extends HttpMessage implements \ArrayAccess, \JsonSerializable, ResponseInterface {
     /// Properties ///
 
     /**
@@ -477,5 +479,14 @@ class HttpResponse extends HttpMessage implements \ArrayAccess, \JsonSerializabl
             "request" => $this->getRequest(),
             "body" => $this->getRawBody(),
         ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function withStatus(int $code, string $reasonPhrase = '') {
+        $cloned = clone $this;
+        $cloned->setStatus($code);
+        return $cloned;
     }
 }

--- a/src/Mocks/MockHttpHandler.php
+++ b/src/Mocks/MockHttpHandler.php
@@ -10,6 +10,7 @@ namespace Garden\Http\Mocks;
 use Garden\Http\HttpHandlerInterface;
 use Garden\Http\HttpRequest;
 use Garden\Http\HttpResponse;
+use PHPUnit\Framework\Assert;
 
 /**
  * Handler for mock http requests. Never makes any actual network requests.
@@ -18,12 +19,106 @@ class MockHttpHandler implements HttpHandlerInterface {
 
     use MockHttpRequestTrait;
 
+    /** @var MockHttpHandler|null */
+    public static ?MockHttpHandler $mock = null;
+
+    /** @var array<HttpRequest> */
+    private array $history = [];
+
     /**
      * @inheritDoc
      */
     public function send(HttpRequest $request): HttpResponse {
         $response = $this->dispatchMockRequest($request);
         $response->setRequest($request);
+        $request->setResponse($response);
         return $response;
+    }
+
+    /**
+     * Mock all incoming network requests to garden-http.
+     *
+     * @return MockHttpHandler The mocked handler.
+     */
+    public static function mock(): MockHttpHandler {
+        if (self::$mock === null) {
+            self::$mock = new MockHttpHandler();
+        }
+
+        return self::$mock;
+    }
+
+    /**
+     * @return MockHttpHandler|null
+     */
+    public static function getMock(): ?MockHttpHandler {
+        return self::$mock;
+    }
+
+    /**
+     * Clear the mock and allow normal requests to take place.
+     *
+     * @return void
+     */
+    public static function clearMock(): void {
+        self::$mock = null;
+    }
+
+    /**
+     * Reset the mocked requests/responses.
+     *
+     * @return MockHttpHandler
+     */
+    public function reset(): MockHttpHandler {
+        $this->history = [];
+        $this->mockRequests = [];
+        self::$mock = new MockHttpHandler();
+        return self::$mock;
+    }
+
+    /**
+     * Assert that no requests were sent.
+     *
+     * @return void
+     */
+    public function assertNothingSent(): void {
+        $historyIDs = $this->getHistoryIDs();
+        Assert::assertEmpty($this->history, "Expected no requests to be sent. Instead received " . count($historyIDs) . ".\n" . implode("\n", $historyIDs));
+    }
+
+    /**
+     * Assert that a request was sent that matches a callable.
+     *
+     * @param callable(HttpRequest $request): bool $matcher
+     *
+     * @return HttpRequest
+     */
+    public function assertSent(callable $matcher): HttpRequest {
+        $matchingRequest = null;
+        foreach ($this->history as $request) {
+            $result = call_user_func($matcher, $request);
+            if ($result) {
+                $matchingRequest = $request;
+                break;
+            }
+        }
+
+        $historyIDs = $this->getHistoryIDs();
+        if (empty($historyIDs)) {
+            Assert::fail("Expected to find a matching request. Instead no requests were sent.");
+        }
+        Assert::assertInstanceOf(HttpRequest::class, $matchingRequest, "Expected to find a matching request. Instead there were " . count($historyIDs) . " requests that did not match.\n" . implode("\n", $historyIDs));
+        return $matchingRequest;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getHistoryIDs(): array {
+        $historyIDs = [];
+        foreach ($this->history as $historyItem) {
+            $historyIDs[] = "{$historyItem->getMethod()} {$historyItem->getUrl()}";
+        }
+        return $historyIDs;
     }
 }

--- a/src/Mocks/MockHttpRequestTrait.php
+++ b/src/Mocks/MockHttpRequestTrait.php
@@ -38,11 +38,18 @@ trait MockHttpRequestTrait {
         });
 
         $bestMock = $matchedMocks[0] ?? null;
+
+
         if ($bestMock == null) {
-            return new HttpResponse(404);
+            $response = new HttpResponse(404);
         } else {
-            return $bestMock->getResponse();
+            $response = $bestMock->getResponse();
         }
+
+        $response->setRequest($request);
+        $request->setResponse($response);
+        $this->history[] = $request;
+        return $response;
     }
 
     /**

--- a/tests/Fixtures/EchoHandler.php
+++ b/tests/Fixtures/EchoHandler.php
@@ -25,6 +25,7 @@ class EchoHandler implements HttpHandlerInterface {
         ]);
 
         $response->setRequest($request);
+        $request->setResponse($response);
 
         return $response;
     }

--- a/tests/Fixtures/MockRequest.php
+++ b/tests/Fixtures/MockRequest.php
@@ -48,6 +48,7 @@ class MockRequest extends HttpRequest {
 
         $response = new HttpResponse(200, ['Content-Type' => 'application/json'], json_encode($result));
         $response->setRequest($request);
+        $request->setResponse($response);
 
         return $response;
     }


### PR DESCRIPTION
This PR adds PSR-7 compatibility for the request, response, and message classes.

Since `slim-psr7` was already a dev-dependency, I've bumped that up to a normal dep to use it's `Uri` and `UriFactory` implementations.