### PR TITLE
Add connect timeout support and improve the error messages from curl errors

### DIFF
--- a/src/CurlHandler.php
+++ b/src/CurlHandler.php
@@ -83,6 +83,7 @@ class CurlHandler implements HttpHandlerInterface {
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_TIMEOUT, $request->getTimeout());
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $request->getConnectTimeout());
         curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_HEADER, true);

--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -12,6 +12,7 @@ namespace Garden\Http;
  * Represents an client connection to a RESTful API.
  */
 class HttpClient {
+
     /// Properties ///
 
     /**
@@ -325,7 +326,7 @@ class HttpClient {
     /**
      * Set the value of a default option.
      *
-     * @param string $name The name of the default option.
+     * @param string $name The name of the default option. One of the {@link HttpRequest::OPT_*} constants.
      * @param mixed $value The new value of the default option.
      * @return HttpClient Returns `$this` for fluent calls.
      */
@@ -366,7 +367,8 @@ class HttpClient {
     /**
      * Set the default options.
      *
-     * @param array $defaultOptions The new default options array.
+     * @param array<string, mixed> $defaultOptions The new default options array.
+     * Keys are the OPT_* constants from {@link HttpRequest::OPT_*}.
      * @return HttpClient Returns `$this` for fluent calls.
      */
     public function setDefaultOptions(array $defaultOptions) {

--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -271,6 +271,7 @@ class HttpRequest extends HttpMessage implements \JsonSerializable, RequestInter
     public function jsonSerialize(): array {
         return [
             "url" => $this->getUrl(),
+            "host" => $this->getHeader("host") ?: $this->getUri()->getHost(),
             "method" => $this->getMethod(),
         ];
     }

--- a/src/HttpRequest.php
+++ b/src/HttpRequest.php
@@ -18,6 +18,12 @@ use Slim\Psr7\Factory\UriFactory;
 class HttpRequest extends HttpMessage implements \JsonSerializable, RequestInterface {
     /// Constants ///
 
+    public const OPT_TIMEOUT = "timeout";
+    public const OPT_CONNECT_TIMEOUT = "connectTimeout";
+    public const OPT_VERIFY_PEER = "verifyPeer";
+    public const OPT_PROTOCOL_VERSION = "protocolVersion";
+    public const OPT_AUTH = "auth";
+
     const METHOD_DELETE = 'DELETE';
     const METHOD_GET = 'GET';
     const METHOD_HEAD = 'HEAD';
@@ -47,6 +53,9 @@ class HttpRequest extends HttpMessage implements \JsonSerializable, RequestInter
      * @var int
      */
     protected $timeout = 0;
+
+    /** @var int */
+    protected $connectTimeout = 0;
 
     /**
      * @var bool
@@ -78,17 +87,11 @@ class HttpRequest extends HttpMessage implements \JsonSerializable, RequestInter
         $this->setBody($body);
         $this->setHeaders($headers);
 
-        $options += [
-            'protocolVersion' => '1.1',
-            'auth' => [],
-            'timeout' => 0,
-            'verifyPeer' => true
-        ];
-
-        $this->setProtocolVersion($options['protocolVersion']);
-        $this->setAuth($options['auth']);
-        $this->setVerifyPeer($options['verifyPeer']);
-        $this->setTimeout($options['timeout']);
+        $this->setProtocolVersion($options[self::OPT_PROTOCOL_VERSION] ?? "1.1");
+        $this->setAuth($options[self::OPT_AUTH] ?? []);
+        $this->setVerifyPeer($options[self::OPT_VERIFY_PEER] ?? true);
+        $this->setConnectTimeout($options[self::OPT_CONNECT_TIMEOUT] ?? 0);
+        $this->setTimeout($options[self::OPT_TIMEOUT] ?? 0);
     }
 
     /**
@@ -225,6 +228,22 @@ class HttpRequest extends HttpMessage implements \JsonSerializable, RequestInter
      */
     public function setTimeout(int $timeout) {
         $this->timeout = $timeout;
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getConnectTimeout(): int {
+        return $this->connectTimeout;
+    }
+
+    /**
+     * @param int $connectTimeout
+     * @return void
+     */
+    public function setConnectTimeout(int $connectTimeout): HttpRequest {
+        $this->connectTimeout = $connectTimeout;
         return $this;
     }
 

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -485,6 +485,8 @@ class HttpResponse extends HttpMessage implements \ArrayAccess, \JsonSerializabl
             "content-type" => $this->getHeader("content-type") ?: null,
             "request" => $this->getRequest(),
             "body" => $this->getRawBody(),
+            "cf-ray" => $this->getHeader("cf-ray") ?: null,
+            "cf-cache-status" => $this->getHeader("cf-cache-status") ?: null,
         ];
     }
 

--- a/src/HttpResponse.php
+++ b/src/HttpResponse.php
@@ -294,7 +294,14 @@ class HttpResponse extends HttpMessage implements \ArrayAccess, \JsonSerializabl
      * @return string Returns the reason phrase.
      */
     public function getReasonPhrase(): string {
-        return $this->reasonPhrase;
+        if ($this->statusCode === 0 && !empty($this->rawBody)) {
+            // CURL often returns a 0 error code if it failed to connect.
+            // This could be for multiple reasons. We need the actual message provided to differentiate between
+            // a timeout vs a DNS resolution failure.
+            return $this->rawBody;
+        } else {
+            return $this->reasonPhrase;
+        }
     }
 
     /**

--- a/tests/HttpResponseExceptionTest.php
+++ b/tests/HttpResponseExceptionTest.php
@@ -21,13 +21,14 @@ class HttpResponseExceptionTest extends TestCase {
      */
     public function testJsonSerialize(): void {
         $response = new HttpResponse(501, ["content-type" => "application/json", "Cf-Ray" => "ray-id-12345"], '{"message":"Some error occured."}');
-        $response->setRequest(new HttpRequest("POST", "/some/path"));
+        $response->setRequest(new HttpRequest("POST", "https://somesite.com/some/path"));
         $this->assertEquals([
-            "message" => 'Request "POST /some/path" failed with a response code of 501 and a custom message of "Some error occured."',
+            "message" => 'Request "POST https://somesite.com/some/path" failed with a response code of 501 and a custom message of "Some error occured."',
             "status" => 501,
             "code" => 501,
             "request" => [
-                'url' => '/some/path',
+                'url' => 'https://somesite.com/some/path',
+                "host" => "somesite.com",
                 'method' => 'POST',
             ],
             "response" => [
@@ -39,6 +40,19 @@ class HttpResponseExceptionTest extends TestCase {
             ],
             'class' => 'Garden\Http\HttpResponseException',
         ], $response->asException()->jsonSerialize());
+    }
+
+    /**
+     * @return void
+     */
+    public function testHostSiteOverrideSerialize() {
+        $request = new HttpRequest("GET", "https://proxy-server.com/some/path", ["Host" => "example.com"]);
+        $serialized = $request->jsonSerialize();
+        $this->assertEquals([
+            "url" => "https://proxy-server.com/some/path",
+            "host" => "proxy-server.com",
+            "method" => "GET",
+        ], $serialized);
     }
 
     /**

--- a/tests/HttpResponseExceptionTest.php
+++ b/tests/HttpResponseExceptionTest.php
@@ -20,7 +20,7 @@ class HttpResponseExceptionTest extends TestCase {
      * Test json serialize implementation of exceptions.
      */
     public function testJsonSerialize(): void {
-        $response = new HttpResponse(501, ["content-type" => "application/json"], '{"message":"Some error occured."}');
+        $response = new HttpResponse(501, ["content-type" => "application/json", "Cf-Ray" => "ray-id-12345"], '{"message":"Some error occured."}');
         $response->setRequest(new HttpRequest("POST", "/some/path"));
         $this->assertEquals([
             "message" => 'Request "POST /some/path" failed with a response code of 501 and a custom message of "Some error occured."',
@@ -34,6 +34,8 @@ class HttpResponseExceptionTest extends TestCase {
                 'statusCode' => 501,
                 'content-type' => 'application/json',
                 'body' => '{"message":"Some error occured."}',
+                "cf-ray" => "ray-id-12345",
+                "cf-cache-status" => null,
             ],
             'class' => 'Garden\Http\HttpResponseException',
         ], $response->asException()->jsonSerialize());
@@ -55,6 +57,8 @@ class HttpResponseExceptionTest extends TestCase {
                 'statusCode' => 500,
                 'content-type' => 'application/json',
                 'body' => '{"error":"hi"}',
+                "cf-ray" => null,
+                "cf-cache-status" => null,
             ],
             'request' => null,
         ], $response->asException()->jsonSerialize());

--- a/tests/ReadmeTest.php
+++ b/tests/ReadmeTest.php
@@ -18,19 +18,16 @@ use PHPUnit\Framework\TestCase;
 class ReadmeTest extends TestCase {
     public function testBasicExample() {
         $api = new HttpClient('http://httpbin.org');
+        $api->setThrowExceptions(true);
         $api->setDefaultHeader('Content-Type', 'application/json');
 
         // Get some data from the API.
         $response = $api->get('/get'); // requests off of base url
-        if ($response->isSuccessful()) {
-            $data = $response->getBody(); // returns array of json decoded data
-        }
+        $data = $response->getBody(); // returns array of json decoded data
 
         $response = $api->post('https://httpbin.org/post', ['foo' => 'bar']);
-        if ($response->isResponseClass('2xx')) {
-            // Access the response like an array.
-            $posted = $response['json']; // should be ['foo' => 'bar']
-        }
+        // Access the response like an array.
+        $posted = $response['json']; // should be ['foo' => 'bar']
 
         if (!$response->isSuccessful()) {
             $this->markTestSkipped();


### PR DESCRIPTION
## Changes

- Add support setting connect_timeout for the curl handler.
- Add constants on `HttpRequest` for all request options.
- Improve exception messages when getting curl error code 0.
  - The underlying curl error will now be exposed. For example: "Failed to connect to 0.0.0.0 port 8091 after 0 ms: Couldn't connect to server"