### PR TITLE
Enhance PHP 8.3 compatibility

### DIFF
--- a/src/HttpClient.php
+++ b/src/HttpClient.php
@@ -11,6 +11,7 @@ namespace Garden\Http;
 /**
  * Represents an client connection to a RESTful API.
  */
+#[\AllowDynamicProperties]
 class HttpClient {
 
     /// Properties ///


### PR DESCRIPTION
The Vanilla platform dynamically adds properties to HttpClient. This isn't allowed by default in PHP 8.3.
This PR fixes it.

Related issue: https://higherlogic.atlassian.net/browse/VNLA-8944